### PR TITLE
Fix Sys.glob described as regex instead of glob

### DIFF
--- a/03-reading_writing_data.Rmd
+++ b/03-reading_writing_data.Rmd
@@ -59,7 +59,7 @@ to import all the datasets in a single directory at once. For this, you first ne
 paths <- Sys.glob("datasets/unemployment/*.csv")
 ```
 
-`Sys.glob()` allows you to find files using a regular expression. "datasets/unemployment/*.csv"
+`Sys.glob()` allows you to find files using wildcards. "datasets/unemployment/*.csv"
 matches all the `.csv` files inside the "datasets/unemployment/" folder.
 
 ```{r}


### PR DESCRIPTION
`Sys.glob` (like most globbing tools), uses wildcard expansion, called [globbing](https://en.wikipedia.org/wiki/Glob_(programming)), not regular expressions. See here: https://www.rdocumentation.org/packages/base/versions/3.6.2/topics/Sys.glob